### PR TITLE
Message sarcasme -> réaction :warning: au message

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,11 +31,7 @@ client.on('message', message => {
 
     //event
     if (message.content.match(/!s/)) {
-        if (message.author.id === '489032872355823626' || message.author.id === '626056738038087691') {
-            message.channel.send(':warning: ELLE RIGOLE :warning: (l\'autrice indique que le sarcasme a été utilisé)');
-        } else {
-            message.channel.send(':warning: IL RIGOLE :warning: (l\'auteur indique que le sarcasme a été utilisé)');
-        }
+        message.react('⚠');
     }
 
     if (message.content[0] != PREFIX) return;


### PR DESCRIPTION
La précédente implémentation de l'indicateur de sarcasme consistait à envoyer un message sur le même canal que le message d'origine afin de signaler le sarcasme qu'il relevait.

Cependant, cette implémentation, excessivement verbeuse, a rapidement soulevé un problème majeur, le spam : 

![image](https://user-images.githubusercontent.com/42067072/106298218-eba1f700-6253-11eb-9418-9a9569ff76e8.png)

Une modification a ainsi été mise en place permettant d'ajouter automatiquement la réaction ⚠️ aux messages qui comportent le code `!s`.

Voici un résultat de l'implémentation, testée : 

![image](https://user-images.githubusercontent.com/42067072/106298515-450a2600-6254-11eb-99ab-f1c5c776e411.png)
